### PR TITLE
Add flash attention

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,13 @@ RUN python -m pip install gguf transformers==4.56.2
 # ComfyUI
 RUN git clone --depth=1 https://github.com/comfyanonymous/ComfyUI.git /opt/ComfyUI 
 WORKDIR /opt/ComfyUI
+ENV TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
+ENV FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE"
+ENV FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON='{"BLOCK_M":128,"BLOCK_N":64,"waves_per_eu":1,"PRE_LOAD_V":false,"num_stages":1,"num_warps":8}'
 RUN python -m pip install -r requirements.txt && \
     python -m pip install --prefer-binary \
-    pillow opencv-python-headless imageio imageio-ffmpeg scipy "huggingface_hub[hf_transfer]" pyyaml websocket-client
+    pillow opencv-python-headless imageio imageio-ffmpeg scipy "huggingface_hub[hf_transfer]" pyyaml websocket-client && \
+    pip install flash-attn --no-build-isolation
 
 COPY workflows/input/ai-server.jpg /opt/ComfyUI/input/
 COPY workflows/input/ai-server-2.png /opt/ComfyUI/input/

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ RUN python -m pip install gguf transformers==4.56.2
 # ComfyUI
 RUN git clone --depth=1 https://github.com/comfyanonymous/ComfyUI.git /opt/ComfyUI 
 WORKDIR /opt/ComfyUI
-ENV TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
 ENV FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE"
 ENV FLASH_ATTENTION_FWD_TRITON_AMD_CONFIG_JSON='{"BLOCK_M":128,"BLOCK_N":64,"waves_per_eu":1,"PRE_LOAD_V":false,"num_stages":1,"num_warps":8}'
 RUN python -m pip install -r requirements.txt && \

--- a/scripts/99-toolbox-banner.sh
+++ b/scripts/99-toolbox-banner.sh
@@ -87,4 +87,4 @@ echo
 printf 'SSH tip: ssh -L 8000:localhost:8000 user@host\n\n'
 
 # Aliases
-alias start_comfy_ui='cd /opt/ComfyUI && python main.py --port 8000 --output-directory $HOME/comfy-outputs --disable-mmap --gpu-only --disable-smart-memory --cache-none --bf16-vae'
+alias start_comfy_ui='cd /opt/ComfyUI && python main.py --port 8000 --output-directory $HOME/comfy-outputs --disable-mmap --gpu-only --disable-smart-memory --cache-none --bf16-vae --use-flash-attention'

--- a/scripts/benchmark_workflows.py
+++ b/scripts/benchmark_workflows.py
@@ -227,7 +227,7 @@ def main():
                 sys.executable, "main.py",
                 "--port", server_port,
                 "--output-directory", comfy_outputs_dir,
-                "--disable-mmap", "--bf16-vae", "--gpu-only", "--disable-smart-memory", "--cache-none"
+                "--disable-mmap", "--bf16-vae", "--gpu-only", "--disable-smart-memory", "--cache-none", "--use-flash-attention"
             ]
             
             log_file = open("server.log", "w") # Overwrite log for each run

--- a/scripts/collect_perf_logs.py
+++ b/scripts/collect_perf_logs.py
@@ -107,7 +107,7 @@ def main():
             sys.executable, "main.py",
             "--port", str(server_port),
             "--output-directory", comfy_outputs_dir,
-            "--disable-mmap", "--bf16-vae", "--gpu-only", "--disable-smart-memory", "--cache-none"
+            "--disable-mmap", "--bf16-vae", "--gpu-only", "--disable-smart-memory", "--cache-none", "--use-flash-attention"
         ]
         
         # We capture the server stdout/stderr to this file


### PR DESCRIPTION
First and foremost: thanks for your continued work making our Strix Halo platforms actually useful!

I noticed that the ComfyUI docker has neither Sage- not Flash Attention activated, leacing some performance on the table. This short PR builds and installs Flash Attention - in order to be activated, users need to start `main.py` with `--use-flash-attention`  or use the script's I've adapted.

In my first tests with Flux Klein 9B, executing 4 steps for an 1200x1600 image went down from about 120 secs to 85 secs.